### PR TITLE
Avoid HEAD request to return false

### DIFF
--- a/src/SafeCurl.php
+++ b/src/SafeCurl.php
@@ -176,6 +176,11 @@ class SafeCurl
         $headerSize = curl_getinfo($this->curlHandle, CURLINFO_HEADER_SIZE);
         $response = substr($response, $headerSize);
 
+        // substr return false when string goes empty (in case of a HEAD request for example)
+        if (false === $response) {
+            return '';
+        }
+
         return $response;
     }
 }

--- a/src/SafeCurl.php
+++ b/src/SafeCurl.php
@@ -176,7 +176,7 @@ class SafeCurl
         $headerSize = curl_getinfo($this->curlHandle, CURLINFO_HEADER_SIZE);
         $response = substr($response, $headerSize);
 
-        // substr return false when string goes empty (in case of a HEAD request for example)
+        // substr return false when string goes empty (in case of a HEAD request or when reponse body is empty for example)
         if (false === $response) {
             return '';
         }

--- a/tests/SafeCurlTest.php
+++ b/tests/SafeCurlTest.php
@@ -5,12 +5,25 @@ use fin1te\SafeCurl\Options;
 
 class SafeCurlTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFunctionnal()
+    public function testFunctionnalGET()
     {
         $handle = curl_init();
 
         $safeCurl = new SafeCurl($handle);
         $response = $safeCurl->execute('http://www.google.com');
+
+        $this->assertNotEmpty($response);
+        $this->assertEquals($handle, $safeCurl->getCurlHandle());
+        $this->assertNotContains('HTTP/1.1 302 Found', $response);
+    }
+
+    public function testFunctionnalHEAD()
+    {
+        $handle = curl_init();
+        curl_setopt($handle, CURLOPT_CUSTOMREQUEST, 'HEAD');
+
+        $safeCurl = new SafeCurl($handle);
+        $response = $safeCurl->execute('https://40.media.tumblr.com/39e917383bf5fe228b82fef850251220/tumblr_nxyw8cjiYx1u7jfjwo1_500.jpg');
 
         $this->assertNotEmpty($response);
         $this->assertEquals($handle, $safeCurl->getCurlHandle());

--- a/tests/SafeCurlTest.php
+++ b/tests/SafeCurlTest.php
@@ -23,7 +23,7 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
         curl_setopt($handle, CURLOPT_CUSTOMREQUEST, 'HEAD');
 
         $safeCurl = new SafeCurl($handle);
-        $response = $safeCurl->execute('https://40.media.tumblr.com/39e917383bf5fe228b82fef850251220/tumblr_nxyw8cjiYx1u7jfjwo1_500.jpg');
+        $response = $safeCurl->execute('http://40.media.tumblr.com/39e917383bf5fe228b82fef850251220/tumblr_nxyw8cjiYx1u7jfjwo1_500.jpg');
 
         $this->assertNotEmpty($response);
         $this->assertEquals($handle, $safeCurl->getCurlHandle());

--- a/tests/SafeCurlTest.php
+++ b/tests/SafeCurlTest.php
@@ -20,12 +20,14 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
     public function testFunctionnalHEAD()
     {
         $handle = curl_init();
-        curl_setopt($handle, CURLOPT_CUSTOMREQUEST, 'HEAD');
+        // for an unknown reason, HEAD request failed: https://travis-ci.org/j0k3r/safecurl/jobs/91936743
+        // curl_setopt($handle, CURLOPT_CUSTOMREQUEST, 'HEAD');
+        curl_setopt($handle, CURLOPT_NOBODY, true);
 
         $safeCurl = new SafeCurl($handle);
-        $response = $safeCurl->execute('http://40.media.tumblr.com/39e917383bf5fe228b82fef850251220/tumblr_nxyw8cjiYx1u7jfjwo1_500.jpg');
+        $response = $safeCurl->execute('http://40.media.tumblr.com/39e917383bf5fe228b82fef850251220/tumblr_nxyw8cjiYx1u7jfjwo1_100.jpg');
 
-        $this->assertNotEmpty($response);
+        $this->assertEquals('', $response);
         $this->assertEquals($handle, $safeCurl->getCurlHandle());
         $this->assertNotContains('HTTP/1.1 302 Found', $response);
     }


### PR DESCRIPTION
`substr` return false when the extracted string is empty. We don't want that.
