### PR TITLE
Revert "Add Accept: */* header"

### DIFF
--- a/src/SafeCurl.php
+++ b/src/SafeCurl.php
@@ -101,7 +101,7 @@ class SafeCurl
 
             if ($this->getOptions()->getPinDns()) {
                 //Send a Host header
-                curl_setopt($this->curlHandle, CURLOPT_HTTPHEADER, array('Host: '.$url['host']));
+                curl_setopt($this->curlHandle, CURLOPT_HTTPHEADER, array('Host: ' . $url['host']));
                 //The "fake" URL
                 curl_setopt($this->curlHandle, CURLOPT_URL, $url['url']);
                 //We also have to disable SSL cert verfication, which is not great

--- a/src/SafeCurl.php
+++ b/src/SafeCurl.php
@@ -99,10 +99,9 @@ class SafeCurl
             //Validate the URL
             $url = Url::validateUrl($url, $this->getOptions());
 
-            $headers = array('Accept: */*');
             if ($this->getOptions()->getPinDns()) {
                 //Send a Host header
-                $headers[] = 'Host: ' . $url['host'];
+                curl_setopt($this->curlHandle, CURLOPT_HTTPHEADER, array('Host: '.$url['host']));
                 //The "fake" URL
                 curl_setopt($this->curlHandle, CURLOPT_URL, $url['url']);
                 //We also have to disable SSL cert verfication, which is not great
@@ -111,7 +110,6 @@ class SafeCurl
             } else {
                 curl_setopt($this->curlHandle, CURLOPT_URL, $url['url']);
             }
-            curl_setopt($this->curlHandle, CURLOPT_HTTPHEADER, $headers);
 
             // in case of `CURLINFO_REDIRECT_URL` isn't defined
             curl_setopt($this->curlHandle, CURLOPT_HEADER, true);


### PR DESCRIPTION
We got some many side effects when declaring `headers` that way. Even if by reading the code, everything should work as normal.
Like in https://github.com/j0k3r/graby/issues/162.
But also, paywall stuff in wallabag doesn't work anymore because some headers are missing after few requests.

It was really hard to debug and it's still hard to describe a real scenario to allow someone to fix the problem.
As a conclusion, reverting the PR is a better solution at the moment.

Reverts j0k3r/safecurl#4