### PR TITLE
Dropping PHP < 7.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /.scrutinizer.yml export-ignore
-/README.md export-ignore
 /phpunit.xml export-ignore
 /tests export-ignore
 /example export-ignore
+/build export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 build
 .php_cs.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,12 @@ os: linux
 language: php
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
     - 7.3
     - 7.4
     - nightly
 
 jobs:
     include:
-        - php: 5.3.3
-          dist: precise
-        - php: 5.3
-          dist: precise
-        - php: 5.4
-          dist: precise
         - php: 7.2
           env: CS_FIXER=run
     fast_finish: true
@@ -32,21 +21,14 @@ cache:
         - vendor
         - $HOME/.composer/cache
 
-before_install:
-    # disable TLS for composer because openssl is disabled for PHP 5.3.3 on travis
-    # see: https://blog.travis-ci.com/upcoming_ubuntu_11_10_migration/
-    - if [[ $TRAVIS_PHP_VERSION = 5.3.3 ]]; then composer config -g -- disable-tls true; fi;
-    - if [[ $TRAVIS_PHP_VERSION = 5.3.3 ]]; then composer config -g -- secure-http false; fi;
-
 install:
     - composer self-update
 
 before_script:
-    - composer install --prefer-dist --no-interaction
+    - composer install --prefer-dist --no-interaction -o
 
 script:
-    - ./vendor/bin/phpunit --coverage-clover=coverage.clover
-    - if [ "$CS_FIXER" = "run" ]; then composer require friendsofphp/php-cs-fixer "~2.0" ; fi;
+    - php vendor/bin/simple-phpunit -v --coverage-clover=coverage.clover
     - if [ "$CS_FIXER" = "run" ]; then php vendor/bin/php-cs-fixer fix --verbose --dry-run ; fi;
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+os: linux
 language: php
 
 php:
@@ -6,35 +8,29 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
+    - 7.4
     - nightly
-    - hhvm
 
-matrix:
+jobs:
     include:
         - php: 5.3.3
           dist: precise
-          sudo: required
         - php: 5.3
           dist: precise
-          sudo: required
         - php: 5.4
           dist: precise
-          sudo: required
         - php: 7.2
           env: CS_FIXER=run
     fast_finish: true
     allow_failures:
         - php: nightly
-        - php: hhvm
 
 # cache vendor dirs
 cache:
     directories:
         - vendor
         - $HOME/.composer/cache
-
-# faster builds on new travis setup not using sudo
-sudo: false
 
 before_install:
     # disable TLS for composer because openssl is disabled for PHP 5.3.3 on travis

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SafeCurl can be included in any PHP project using [Composer](https://getcomposer
 
 ```
 "require": {
-    "j0k3r\safecurl": "~2.0"
+    "j0k3r\safecurl": "~3.0"
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": "^7.2",
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0.0"
+        "symfony/phpunit-bridge": "^5.0",
+        "friendsofphp/php-cs-fixer": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>
@@ -23,6 +22,6 @@
     </filter>
 
     <logging>
-        <log type="coverage-html" target="build/coverage" title="safecurl" charset="UTF-8" yui="true" highlight="true" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-html" target="build/coverage" lowUpperBound="35" highLowerBound="70"/>
     </logging>
 </phpunit>

--- a/src/Options.php
+++ b/src/Options.php
@@ -214,7 +214,7 @@ class Options
             throw new InvalidOptionException('Provided list "' . $list . '" must be "whitelist" or "blacklist"');
         }
 
-        if (!array_key_exists($type, $this->$list)) {
+        if (!\array_key_exists($type, $this->$list)) {
             throw new InvalidOptionException('Provided type "' . $type . '" must be "ip", "port", "domain" or "scheme"');
         }
 
@@ -257,7 +257,7 @@ class Options
         }
 
         if (null !== $type) {
-            if (!array_key_exists($type, $this->$list)) {
+            if (!\array_key_exists($type, $this->$list)) {
                 throw new InvalidOptionException('Provided type "' . $type . '" must be "ip", "port", "domain" or "scheme"');
             }
 
@@ -287,7 +287,7 @@ class Options
         }
 
         if (null !== $type) {
-            if (!array_key_exists($type, $this->$list)) {
+            if (!\array_key_exists($type, $this->$list)) {
                 throw new InvalidOptionException('Provided type "' . $type . '" must be "ip", "port", "domain" or "scheme"');
             }
 
@@ -322,7 +322,7 @@ class Options
             throw new InvalidOptionException('Provided list "' . $list . '" must be "whitelist" or "blacklist"');
         }
 
-        if (!array_key_exists($type, $this->$list)) {
+        if (!\array_key_exists($type, $this->$list)) {
             throw new InvalidOptionException('Provided type "' . $type . '" must be "ip", "port", "domain" or "scheme"');
         }
 
@@ -359,7 +359,7 @@ class Options
             throw new InvalidOptionException('Provided list "' . $list . '" must be "whitelist" or "blacklist"');
         }
 
-        if (!array_key_exists($type, $this->$list)) {
+        if (!\array_key_exists($type, $this->$list)) {
             throw new InvalidOptionException('Provided type "' . $type . '" must be "ip", "port", "domain" or "scheme"');
         }
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -31,17 +31,17 @@ class Url
             throw new InvalidURLException('Error parsing URL "' . $url . '"');
         }
 
-        if (!array_key_exists('host', $parts)) {
+        if (!\array_key_exists('host', $parts)) {
             throw new InvalidURLException('Provided URL "' . $url . '" doesn\'t contain a hostname');
         }
 
         //If credentials are passed in, but we don't want them, raise an exception
-        if (!$options->getSendCredentials() && (array_key_exists('user', $parts) || array_key_exists('pass', $parts))) {
+        if (!$options->getSendCredentials() && (\array_key_exists('user', $parts) || \array_key_exists('pass', $parts))) {
             throw new InvalidURLException('Credentials passed in but "sendCredentials" is set to false');
         }
 
         //First, validate the scheme
-        if (array_key_exists('scheme', $parts)) {
+        if (\array_key_exists('scheme', $parts)) {
             $parts['scheme'] = self::validateScheme($parts['scheme'], $options);
         } else {
             //Default to http
@@ -49,7 +49,7 @@ class Url
         }
 
         //Validate the port
-        if (array_key_exists('port', $parts)) {
+        if (\array_key_exists('port', $parts)) {
             $parts['port'] = self::validatePort($parts['port'], $options);
         }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -2,11 +2,11 @@
 
 use fin1te\SafeCurl\Options;
 
-class OptionsTest extends \PHPUnit_Framework_TestCase
+class OptionsTest extends \PHPUnit\Framework\TestCase
 {
     private $options;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->options = new Options();
     }
@@ -44,11 +44,12 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider dataForFollowlocationLimit
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided limit
      */
     public function testFollowlocationLimitException($limit)
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided limit');
+
         $this->options->setFollowLocationLimit($limit);
     }
 
@@ -101,21 +102,19 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->options->isInList('whitelist', 'domain', 'www.fin1te.net'));
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided list "noo" must be "whitelist" or "blacklist"
-     */
     public function testInListBadList()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided list "noo" must be "whitelist" or "blacklist"');
+
         $this->options->isInList('noo', 'domain', '');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided type "noo" must be "ip", "port", "domain" or "scheme"
-     */
     public function testInListBadType()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
+
         $this->options->isInList('whitelist', 'noo', '');
     }
 
@@ -193,21 +192,19 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('ftp', $list[0]);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided list "noo" must be "whitelist" or "blacklist"
-     */
     public function testGetListBadList()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided list "noo" must be "whitelist" or "blacklist"');
+
         $this->options->getList('noo');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided type "noo" must be "ip", "port", "domain" or "scheme"
-     */
     public function testGetListBadType()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
+
         $this->options->getList('whitelist', 'noo');
     }
 
@@ -222,93 +219,83 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(22), $this->options->getList('blacklist', 'port'));
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided list "noo" must be "whitelist" or "blacklist"
-     */
     public function testSetListBadList()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided list "noo" must be "whitelist" or "blacklist"');
+
         $this->options->setList('noo', array());
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided values must be an array, "integer" given
-     */
     public function testSetListBadValue()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided values must be an array, "integer" given');
+
         $this->options->setList('whitelist', 12);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided type "noo" must be "ip", "port", "domain" or "scheme"
-     */
     public function testSetListBadType()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
+
         $this->options->setList('whitelist', array(), 'noo');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided type "noo" must be "ip", "port", "domain" or "scheme"
-     */
     public function testSetListBadTypeValue()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
+
         $this->options->setList('whitelist', array('noo' => 'oops'));
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided list "noo" must be "whitelist" or "blacklist"
-     */
     public function testAddToListBadList()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided list "noo" must be "whitelist" or "blacklist"');
+
         $this->options->addToList('noo', 'noo', 'noo');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided type "noo" must be "ip", "port", "domain" or "scheme"
-     */
     public function testAddToListBadType()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
+
         $this->options->addToList('whitelist', 'noo', 'noo');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided values cannot be empty
-     */
     public function testAddToListBadValue()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided values cannot be empty');
+
         $this->options->addToList('whitelist', 'ip', null);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided list "noo" must be "whitelist" or "blacklist"
-     */
     public function testRemoveFromListBadList()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided list "noo" must be "whitelist" or "blacklist"');
+
         $this->options->removeFromList('noo', 'noo', 'noo');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided type "noo" must be "ip", "port", "domain" or "scheme"
-     */
     public function testRemoveFromListBadType()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided type "noo" must be "ip", "port", "domain" or "scheme"');
+
         $this->options->removeFromList('whitelist', 'noo', 'noo');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidOptionException
-     * @expectedExceptionMessage Provided values cannot be empty
-     */
     public function testRemoveFromListBadValue()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidOptionException::class);
+        $this->expectExceptionMessage('Provided values cannot be empty');
+
         $this->options->removeFromList('whitelist', 'ip', null);
     }
 

--- a/tests/SafeCurlTest.php
+++ b/tests/SafeCurlTest.php
@@ -3,7 +3,7 @@
 use fin1te\SafeCurl\Options;
 use fin1te\SafeCurl\SafeCurl;
 
-class SafeCurlTest extends \PHPUnit_Framework_TestCase
+class SafeCurlTest extends \PHPUnit\Framework\TestCase
 {
     public function testFunctionnalGET()
     {
@@ -14,7 +14,7 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($response);
         $this->assertEquals($handle, $safeCurl->getCurlHandle());
-        $this->assertNotContains('HTTP/1.1 302 Found', $response);
+        $this->assertStringNotContainsString('HTTP/1.1 302 Found', $response);
     }
 
     public function testFunctionnalHEAD()
@@ -29,30 +29,65 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('', $response);
         $this->assertEquals($handle, $safeCurl->getCurlHandle());
-        $this->assertNotContains('HTTP/1.1 302 Found', $response);
+        $this->assertStringNotContainsString('HTTP/1.1 302 Found', $response);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception
-     * @expectedExceptionMessage SafeCurl expects a valid cURL resource - "NULL" provided.
-     */
     public function testBadCurlHandler()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception::class);
+        $this->expectExceptionMessage('SafeCurl expects a valid cURL resource - "NULL" provided.');
+
         new SafeCurl(null);
     }
 
     public function dataForBlockedUrl()
     {
         return array(
-            array('http://0.0.0.0:123', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidPortException', 'Provided port "123" doesn\'t match whitelisted values: 80, 443, 8080'),
-            array('http://127.0.0.1/server-status', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException', 'Provided host "127.0.0.1" resolves to "127.0.0.1", which matches a blacklisted value: 127.0.0.0/8'),
-            array('file:///etc/passwd', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Provided URL "file:///etc/passwd" doesn\'t contain a hostname'),
-            array('ssh://localhost', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException', 'Provided scheme "ssh" doesn\'t match whitelisted values: http, https'),
-            array('gopher://localhost', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException', 'Provided scheme "gopher" doesn\'t match whitelisted values: http, https'),
-            array('telnet://localhost:25', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException', 'Provided scheme "telnet" doesn\'t match whitelisted values: http, https'),
-            array('http://169.254.169.254/latest/meta-data/', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException', 'Provided host "169.254.169.254" resolves to "169.254.169.254", which matches a blacklisted value: 169.254.0.0/16'),
-            array('ftp://myhost.com', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException', 'Provided scheme "ftp" doesn\'t match whitelisted values: http, https'),
-            array('http://user:pass@safecurl.fin1te.net?@google.com/', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Credentials passed in but "sendCredentials" is set to false'),
+            array(
+                'http://0.0.0.0:123',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidPortException::class,
+                'Provided port "123" doesn\'t match whitelisted values: 80, 443, 8080',
+            ),
+            array(
+                'http://127.0.0.1/server-status',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException::class,
+                'Provided host "127.0.0.1" resolves to "127.0.0.1", which matches a blacklisted value: 127.0.0.0/8',
+            ),
+            array(
+                'file:///etc/passwd',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Provided URL "file:///etc/passwd" doesn\'t contain a hostname',
+            ),
+            array(
+                'ssh://localhost',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException::class,
+                'Provided scheme "ssh" doesn\'t match whitelisted values: http, https',
+            ),
+            array(
+                'gopher://localhost',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException::class,
+                'Provided scheme "gopher" doesn\'t match whitelisted values: http, https',
+            ),
+            array(
+                'telnet://localhost:25',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException::class,
+                'Provided scheme "telnet" doesn\'t match whitelisted values: http, https',
+            ),
+            array(
+                'http://169.254.169.254/latest/meta-data/',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException::class,
+                'Provided host "169.254.169.254" resolves to "169.254.169.254", which matches a blacklisted value: 169.254.0.0/16',
+            ),
+            array(
+                'ftp://myhost.com',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException::class,
+                'Provided scheme "ftp" doesn\'t match whitelisted values: http, https',
+            ),
+            array(
+                'http://user:pass@safecurl.fin1te.net?@google.com/',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Credentials passed in but "sendCredentials" is set to false',
+            ),
         );
     }
 
@@ -61,7 +96,8 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
      */
     public function testBlockedUrl($url, $exception, $message)
     {
-        $this->setExpectedException($exception, $message);
+        $this->expectException($exception);
+        $this->expectExceptionMessage($message);
 
         $safeCurl = new SafeCurl(curl_init());
         $safeCurl->execute($url);
@@ -70,8 +106,16 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
     public function dataForBlockedUrlByOptions()
     {
         return array(
-            array('http://login:password@google.fr', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Credentials passed in but "sendCredentials" is set to false'),
-            array('http://safecurl.fin1te.net', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Provided host "safecurl.fin1te.net" matches a blacklisted value'),
+            array(
+                'http://login:password@google.fr',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Credentials passed in but "sendCredentials" is set to false',
+            ),
+            array(
+                'http://safecurl.fin1te.net',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Provided host "safecurl.fin1te.net" matches a blacklisted value',
+            ),
         );
     }
 
@@ -80,7 +124,8 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
      */
     public function testBlockedUrlByOptions($url, $exception, $message)
     {
-        $this->setExpectedException($exception, $message);
+        $this->expectException($exception);
+        $this->expectExceptionMessage($message);
 
         $options = new Options();
         $options->addToList('blacklist', 'domain', '(.*)\.fin1te\.net');
@@ -102,12 +147,11 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($response);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception
-     * @expectedExceptionMessage Redirect limit "1" hit
-     */
     public function testWithFollowLocationLimit()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception::class);
+        $this->expectExceptionMessage('Redirect limit "1" hit');
+
         $options = new Options();
         $options->enableFollowLocation();
         $options->setFollowLocationLimit(1);
@@ -127,12 +171,11 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($response);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidPortException
-     * @expectedExceptionMessage Provided port "123" doesn't match whitelisted values: 80, 443, 8080
-     */
     public function testWithFollowLocationLeadingToABlockedUrl()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception::class);
+        $this->expectExceptionMessage('Provided port "123" doesn\'t match whitelisted values: 80, 443, 8080');
+
         $options = new Options();
         $options->enableFollowLocation();
 
@@ -140,12 +183,11 @@ class SafeCurlTest extends \PHPUnit_Framework_TestCase
         $safeCurl->execute('http://httpbin.org/redirect-to?url=http://0.0.0.0:123');
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception
-     * @expectedExceptionMessage cURL Error:
-     */
     public function testWithCurlTimeout()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception::class);
+        $this->expectExceptionMessage('cURL Error:');
+
         $handle = curl_init();
         curl_setopt($handle, CURLOPT_TIMEOUT_MS, 1);
 

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -3,19 +3,51 @@
 use fin1te\SafeCurl\Options;
 use fin1te\SafeCurl\Url;
 
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends \PHPUnit\Framework\TestCase
 {
     public function dataForValidate()
     {
         return array(
-            array(null, 'fin1te\SafeCurl\Exception\InvalidURLException', 'Provided URL "" cannot be empty'),
-            array('http://user@:80', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Error parsing URL "http://user@:80"'),
-            array('http:///example.com/', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Error parsing URL "http:///example.com/"'),
-            array('http://:80', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Error parsing URL "http://:80"'),
-            array('/nohost', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Provided URL "/nohost" doesn\'t contain a hostname'),
-            array('ftp://domain.io', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException', 'Provided scheme "ftp" doesn\'t match whitelisted values: http, https'),
-            array('http://domain.io:22', 'fin1te\SafeCurl\Exception\InvalidURLException\InvalidPortException', 'Provided port "22" doesn\'t match whitelisted values: 80, 443, 8080'),
-            array('http://login:password@google.fr:80', 'fin1te\SafeCurl\Exception\InvalidURLException', 'Credentials passed in but "sendCredentials" is set to false'),
+            array(
+                null,
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Provided URL "" cannot be empty',
+            ),
+            array(
+                'http://user@:80',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Error parsing URL "http://user@:80"',
+            ),
+            array(
+                'http:///example.com/',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Error parsing URL "http:///example.com/"',
+            ),
+            array(
+                'http://:80',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Error parsing URL "http://:80"',
+            ),
+            array(
+                '/nohost',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Provided URL "/nohost" doesn\'t contain a hostname',
+            ),
+            array(
+                'ftp://domain.io',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException::class,
+                'Provided scheme "ftp" doesn\'t match whitelisted values: http, https',
+            ),
+            array(
+                'http://domain.io:22',
+                \fin1te\SafeCurl\Exception\InvalidURLException\InvalidPortException::class,
+                'Provided port "22" doesn\'t match whitelisted values: 80, 443, 8080',
+            ),
+            array(
+                'http://login:password@google.fr:80',
+                \fin1te\SafeCurl\Exception\InvalidURLException::class,
+                'Credentials passed in but "sendCredentials" is set to false',
+            ),
         );
     }
 
@@ -24,76 +56,71 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateUrl($url, $exception, $message)
     {
-        $this->setExpectedException($exception, $message);
+        $this->expectException($exception);
+        $this->expectExceptionMessage($message);
 
         Url::validateUrl($url, new Options());
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException
-     * @expectedExceptionMessage Provided scheme "http" matches a blacklisted value
-     */
     public function testValidateScheme()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidURLException\InvalidSchemeException::class);
+        $this->expectExceptionMessage('Provided scheme "http" matches a blacklisted value');
+
         $options = new Options();
         $options->addToList('blacklist', 'scheme', 'http');
 
         Url::validateUrl('http://www.fin1te.net', $options);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidPortException
-     * @expectedExceptionMessage Provided port "8080" matches a blacklisted value
-     */
     public function testValidatePort()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidURLException\InvalidPortException::class);
+        $this->expectExceptionMessage('Provided port "8080" matches a blacklisted value');
+
         $options = new Options();
         $options->addToList('blacklist', 'port', '8080');
 
         Url::validateUrl('http://www.fin1te.net:8080', $options);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidDomainException
-     * @expectedExceptionMessage Provided host "www.fin1te.net" matches a blacklisted value
-     */
     public function testValidateHostBlacklist()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidURLException\InvalidDomainException::class);
+        $this->expectExceptionMessage('Provided host "www.fin1te.net" matches a blacklisted value');
+
         $options = new Options();
         $options->addToList('blacklist', 'domain', '(.*)\.fin1te\.net');
 
         Url::validateUrl('http://www.fin1te.net', $options);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidDomainException
-     * @expectedExceptionMessage Provided host "www.google.fr" doesn't match whitelisted values: (.*)\.fin1te\.net
-     */
     public function testValidateHostWhitelist()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidURLException\InvalidDomainException::class);
+        $this->expectExceptionMessage('Provided host "www.google.fr" doesn\'t match whitelisted values: (.*)\.fin1te\.net');
+
         $options = new Options();
         $options->addToList('whitelist', 'domain', '(.*)\.fin1te\.net');
 
         Url::validateUrl('http://www.google.fr', $options);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidDomainException
-     * @expectedExceptionMessage Provided host "www.youpi.boom" doesn't resolve to an IP address
-     */
     public function testValidateHostWithnoip()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidURLException\InvalidDomainException::class);
+        $this->expectExceptionMessage('Provided host "www.youpi.boom" doesn\'t resolve to an IP address');
+
         $options = new Options();
 
         Url::validateUrl('http://www.youpi.boom', $options);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException
-     * @expectedExceptionMessage Provided host "2.2.2.2" resolves to "2.2.2.2", which doesn't match whitelisted values: 1.1.1.1
-     */
     public function testValidateHostWithWhitelistIp()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException::class);
+        $this->expectExceptionMessage('Provided host "2.2.2.2" resolves to "2.2.2.2", which doesn\'t match whitelisted values: 1.1.1.1');
+
         $options = new Options();
         $options->addToList('whitelist', 'ip', '1.1.1.1');
 
@@ -114,12 +141,11 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey(0, $res['ips']);
     }
 
-    /**
-     * @expectedException \fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException
-     * @expectedExceptionMessage Provided host "1.1.1.1" resolves to "1.1.1.1", which matches a blacklisted value: 1.1.1.1
-     */
     public function testValidateHostWithBlacklistIp()
     {
+        $this->expectException(\fin1te\SafeCurl\Exception\InvalidURLException\InvalidIPException::class);
+        $this->expectExceptionMessage('Provided host "1.1.1.1" resolves to "1.1.1.1", which matches a blacklisted value: 1.1.1.1');
+
         $options = new Options();
         $options->addToList('blacklist', 'ip', '1.1.1.1');
 
@@ -138,7 +164,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('host', $res);
         $this->assertArrayHasKey('ips', $res);
         $this->assertArrayHasKey(0, $res['ips']);
-        $this->assertEquals('http://146.185.175.109:8080', $res['url']);
+        $this->assertEquals('http://104.24.104.11:8080', $res['url']);
         $this->assertEquals('www.fin1te.net', $res['host']);
 
         $res = Url::validateUrl('http://www.fin1te.net:8080', new Options());


### PR DESCRIPTION
Prepare for 3.0 because of the BC (dropping PHP < 7.2)

Also:
- cleanup Travis file
- run latest fixer
- make tests compatible with PHPUnit 8+